### PR TITLE
Add Cloudflare Workers caching

### DIFF
--- a/examples/workers/src/index.ts
+++ b/examples/workers/src/index.ts
@@ -2,8 +2,37 @@ import { handleRequest } from '@open-frames/proxy';
 
 export interface Env {}
 
+// Default cache to 1hr
+const DEFAULT_CACHE_LENGTH = 60 * 60;
+
+async function handleWithCache(request: Request, ctx: ExecutionContext): Promise<Response> {
+	const cacheUrl = new URL(request.url);
+
+	// Construct the cache key from the cache URL
+	const cacheKey = new Request(cacheUrl.toString(), request);
+	const cache = caches.default;
+	let response = await cache.match(cacheKey);
+	if (!response) {
+		console.log(`Cache miss for ${request.url}`);
+		response = await handleRequest(request);
+		console.log(response.headers);
+		const cacheControlValue = response.headers.get('cache-control');
+		if (!cacheControlValue) {
+			response.headers.append('cache-control', `s-maxage=${DEFAULT_CACHE_LENGTH}`);
+		}
+		ctx.waitUntil(cache.put(cacheKey, response.clone()));
+	} else {
+		console.log(`Cache hit for ${request.url}`);
+	}
+	return response;
+}
+
 export default {
-	async fetch(request: Request /** _env: Env, _ctx: ExecutionContext **/): Promise<Response> {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+		if (request.method === 'GET') {
+			return handleWithCache(request, ctx);
+		}
 		return handleRequest(request);
 	},
 };

--- a/packages/server/src/parser.test.ts
+++ b/packages/server/src/parser.test.ts
@@ -177,7 +177,7 @@ describe('metadata parsing', () => {
 
 	for (const testCase of testCases) {
 		test(`can extract tags from ${testCase.file}`, async () => {
-			const metaTags = await downloadAndExtract(`http://localhost:${PORT}/${testCase.file}`);
+			const { data: metaTags } = await downloadAndExtract(`http://localhost:${PORT}/${testCase.file}`);
 
 			const extractedTags = metaTagsToObject(metaTags);
 			for (const [key, value] of Object.entries(testCase.expectedTags)) {

--- a/packages/server/src/parser.ts
+++ b/packages/server/src/parser.ts
@@ -32,7 +32,7 @@ export function extractMetaTags(html: string, tagPrefixes = TAG_PREFIXES) {
 	}, []);
 }
 
-const requiredFrameFields: (keyof OpenFrameResult)[] = ['acceptedClients', 'image', 'ogImage'];
+const requiredFrameFields: (keyof OpenFrameResult)[] = ['acceptedClients', 'image'];
 
 export function getFrameInfo(metaTags: MetaTag[]): OpenFrameResult | undefined {
 	const frameInfo: DeepPartial<OpenFrameResult> = {};


### PR DESCRIPTION
## Summary

- Passes through `Cache-Control` headers from origin on GET requests
- In the Cloudflare Workers environment, uses the built-in worker cache to store responses according to the `Cache-Control` header
- If no `Cache-Control` header set, stores GET responses for 1 hour