### PR TITLE
Add account id from the secrets

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,4 +30,5 @@ jobs:
         with:
           packageManager: yarn
           apiToken: ${{ secrets.WORKERS_TOKEN }}
+          accountId: ${{ secrets.WORKERS_ACCOUNT_ID }}
           workingDirectory: examples/workers


### PR DESCRIPTION
## Summary

Cloudflare needs an account ID to deploy this, since it doesn't have the context from my local login. Added that as an argument to the workflow.