### PR TITLE
Handle media errors

### DIFF
--- a/packages/server/src/handlers.test.ts
+++ b/packages/server/src/handlers.test.ts
@@ -68,8 +68,8 @@ describe('media', () => {
 				headers['content-type'] = contentType;
 			}
 			const filePath = `fixtures/${path}`;
-			const file = await readFile(filePath);
 			try {
+				const file = await readFile(filePath);
 				res.writeHead(200, headers);
 				res.end(file);
 			} catch (e) {

--- a/packages/server/src/handlers.test.ts
+++ b/packages/server/src/handlers.test.ts
@@ -109,4 +109,12 @@ describe('media', () => {
 		// Use the content type from the media server, not just the file name
 		expect(response.headers.get('content-type')).toEqual('image/png');
 	});
+
+	test('should pass through status when non-200', async () => {
+		const mediaUrl = `http://localhost:${MEDIA_PORT}/doesnotexist.png`;
+		const mediaRequest = new Request(`http://localhost/media?url=${encodeURIComponent(mediaUrl)}`);
+		const response = await handleMedia(mediaRequest);
+		// Use the content type from the media server, not just the file name
+		expect(response.status).toEqual(404);
+	});
 });

--- a/packages/server/src/handlers.ts
+++ b/packages/server/src/handlers.ts
@@ -72,6 +72,14 @@ export async function handleMedia(req: Request) {
 	const media = await fetch(url, {
 		headers: getProxySafeMediaHeaders(req),
 	});
+
+	if (!media.ok) {
+		return new Response(media.body, {
+			headers: { ...CORS_HEADERS },
+			status: media.status,
+		});
+	}
+
 	// This will include the cache control headers
 	const mediaHeaders = Object.fromEntries(media.headers.entries());
 	const responseHeaders = new Headers({ ...mediaHeaders, ...CORS_HEADERS });


### PR DESCRIPTION
## Summary

- Proxy should pass through non-2xx status codes to the caller for media requests
- Adds a test to verify