### PR TITLE
Noe/add meta tag max size

### DIFF
--- a/.changeset/smart-lobsters-listen.md
+++ b/.changeset/smart-lobsters-listen.md
@@ -1,0 +1,6 @@
+---
+"@open-frames/proxy-client": patch
+"@open-frames/proxy": patch
+---
+
+Adding the max meta tag size parameter

--- a/packages/client/src/actions.ts
+++ b/packages/client/src/actions.ts
@@ -3,8 +3,10 @@ import type { GetMetadataResponse, PostRedirectResponse } from '@open-frames/pro
 import { ApiError } from './errors.js';
 import { JSONSerializable } from './types.js';
 
-export async function readMetadata(url: string, proxyUrl: string): Promise<GetMetadataResponse> {
-	const response = await fetch(`${proxyUrl}?url=${encodeURIComponent(url)}`);
+export async function readMetadata(url: string, proxyUrl: string, maxMetaTagSize?: number | undefined): Promise<GetMetadataResponse> {
+	const response = await fetch(
+		`${proxyUrl}?url=${encodeURIComponent(url)}${maxMetaTagSize ? `&max-meta-tag-bytes=${maxMetaTagSize}` : ''}`,
+	);
 
 	if (!response.ok) {
 		throw new ApiError(`Failed to read metadata for ${url}`, response.status);
@@ -13,14 +15,22 @@ export async function readMetadata(url: string, proxyUrl: string): Promise<GetMe
 	return (await response.json()) as GetMetadataResponse;
 }
 
-export async function post(url: string, payload: JSONSerializable, proxyUrl: string): Promise<GetMetadataResponse> {
-	const response = await fetch(`${proxyUrl}?url=${encodeURIComponent(url)}`, {
-		method: 'POST',
-		body: JSON.stringify(payload),
-		headers: {
-			'Content-Type': 'application/json',
+export async function post(
+	url: string,
+	payload: JSONSerializable,
+	proxyUrl: string,
+	maxMetaTagSize?: number | undefined,
+): Promise<GetMetadataResponse> {
+	const response = await fetch(
+		`${proxyUrl}?url=${encodeURIComponent(url)}${maxMetaTagSize ? `&max-meta-tag-bytes=${maxMetaTagSize}` : ''}`,
+		{
+			method: 'POST',
+			body: JSON.stringify(payload),
+			headers: {
+				'Content-Type': 'application/json',
+			},
 		},
-	});
+	);
 
 	if (!response.ok) {
 		throw new Error(`Failed to post to frame: ${response.status} ${response.statusText}`);

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -5,17 +5,19 @@ import { JSONSerializable } from './types.js';
 
 export class OpenFramesProxy {
 	baseUrl: string;
+	maxMetaTagSize: number | undefined;
 
-	constructor(baseUrl: string) {
+	constructor(baseUrl: string, maxMetaTagSize?: number | undefined) {
 		this.baseUrl = baseUrl;
+		this.maxMetaTagSize = maxMetaTagSize;
 	}
 
 	async readMetadata(url: string): Promise<GetMetadataResponse> {
-		return readMetadata(url, this.baseUrl);
+		return readMetadata(url, this.baseUrl, this.maxMetaTagSize);
 	}
 
 	async post(url: string, payload: JSONSerializable): Promise<GetMetadataResponse> {
-		return post(url, payload, this.baseUrl);
+		return post(url, payload, this.baseUrl, this.maxMetaTagSize);
 	}
 
 	async postRedirect(url: string, payload: JSONSerializable): Promise<PostRedirectResponse> {


### PR DESCRIPTION
Now that the proxy server handles a meta tag max size parameter, add it to the proxy client