### PR TITLE
Account for button post_url in frameInfo

### DIFF
--- a/.changeset/rude-chefs-roll.md
+++ b/.changeset/rude-chefs-roll.md
@@ -1,0 +1,5 @@
+---
+"@open-frames/proxy-types": patch
+---
+
+add button result type

--- a/.changeset/tricky-eyes-trade.md
+++ b/.changeset/tricky-eyes-trade.md
@@ -1,0 +1,5 @@
+---
+"@open-frames/proxy": patch
+---
+
+account for button post_url in frameInfo

--- a/packages/server/src/parser.test.ts
+++ b/packages/server/src/parser.test.ts
@@ -204,7 +204,7 @@ const testCases = [
 					action: 'tx',
 					label: 'button-1',
 					target: EXPECTED_FRAME_POST_URL,
-					post_url: EXPECTED_FRAME_TX_POST_URL,
+					postUrl: EXPECTED_FRAME_TX_POST_URL,
 				},
 			},
 		},

--- a/packages/server/src/parser.test.ts
+++ b/packages/server/src/parser.test.ts
@@ -188,8 +188,7 @@ const testCases = [
 			'of:button:1:target': EXPECTED_FRAME_POST_URL,
 			'of:button:1:post_url': EXPECTED_FRAME_TX_POST_URL,
 		},
-		frameInfo: {
-			ogImage: EXPECTED_FRAME_IMAGE,
+		expectedFrameInfo: {
 			acceptedClients: {
 				xmtp: EXPECTED_FRAME_XMTP_VERSION,
 				lens: '2',
@@ -200,7 +199,6 @@ const testCases = [
 				alt: EXPECTED_IMAGE_ALT,
 			},
 			postUrl: EXPECTED_FRAME_POST_URL,
-			state: EXPECTED_FRAME_STATE,
 			buttons: {
 				'1': {
 					action: 'tx',

--- a/packages/server/src/parser.ts
+++ b/packages/server/src/parser.ts
@@ -1,4 +1,10 @@
-import type { OpenFrameButton, OpenFrameImage, OpenFrameResult, TransactionResponse } from '@open-frames/proxy-types';
+import type {
+	OpenFrameButton,
+	OpenFrameButtonResult,
+	OpenFrameImage,
+	OpenFrameResult,
+	TransactionResponse,
+} from '@open-frames/proxy-types';
 import { load } from 'cheerio';
 
 import { ALLOWED_ACTIONS, FRAMES_PREFIXES, TAG_PREFIXES } from './constants.js';
@@ -110,19 +116,17 @@ function updateFrameButton(frameInfo: DeepPartial<OpenFrameResult>, key: string,
 		return;
 	}
 	frameInfo.buttons = frameInfo.buttons || {};
-	const button = frameInfo.buttons[buttonIndex] || {};
+	const button = (frameInfo.buttons[buttonIndex] as OpenFrameButtonResult) || {};
 	if (maybeField) {
-		const field = maybeField as keyof OpenFrameButton | 'post_url';
+		const field = maybeField as keyof OpenFrameButton;
 		if (field === 'action' && isAllowedAction(value)) {
 			button.action = value;
 		}
 		if (field === 'target') {
 			button.target = value;
 		}
-		if (button.action === 'tx') {
-			if (field === 'post_url') {
-				button.post_url = value;
-			}
+		if (field === 'post_url') {
+			button.postUrl = value;
 		}
 	} else {
 		button.label = value;

--- a/packages/server/src/parser.ts
+++ b/packages/server/src/parser.ts
@@ -112,12 +112,17 @@ function updateFrameButton(frameInfo: DeepPartial<OpenFrameResult>, key: string,
 	frameInfo.buttons = frameInfo.buttons || {};
 	const button = frameInfo.buttons[buttonIndex] || {};
 	if (maybeField) {
-		const field = maybeField as keyof OpenFrameButton;
+		const field = maybeField as keyof OpenFrameButton | 'post_url';
 		if (field === 'action' && isAllowedAction(value)) {
 			button.action = value;
 		}
 		if (field === 'target') {
 			button.target = value;
+		}
+		if (button.action === 'tx') {
+			if (field === 'post_url') {
+				button.post_url = value;
+			}
 		}
 	} else {
 		button.label = value;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -14,17 +14,39 @@ export type OpenFrameButton =
 			action: 'link' | 'mint';
 			target: string;
 			label: string;
+			post_url?: string;
 	  }
 	| {
 			action: 'post' | 'post_redirect';
 			target?: string;
 			label: string;
+			post_url?: string;
 	  }
 	| {
 			action: 'tx';
 			target: string;
 			label: string;
 			post_url: string;
+	  };
+
+export type OpenFrameButtonResult =
+	| {
+			action: 'link' | 'mint';
+			target: string;
+			label: string;
+			postUrl?: string;
+	  }
+	| {
+			action: 'post' | 'post_redirect';
+			target?: string;
+			label: string;
+			postUrl?: string;
+	  }
+	| {
+			action: 'tx';
+			target: string;
+			label: string;
+			postUrl: string;
 	  };
 
 export type TextInput = {
@@ -38,7 +60,7 @@ export type OpenFrameResult = {
 	image: OpenFrameImage;
 	postUrl?: string;
 	textInput?: TextInput;
-	buttons?: { [k: string]: OpenFrameButton };
+	buttons?: { [k: string]: OpenFrameButtonResult };
 	ogImage: string;
 	state?: string;
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -14,7 +14,7 @@ export type OpenFrameButton =
 			action: 'link' | 'mint';
 			target: string;
 			label: string;
-			post_url?: string;
+			post_url: never;
 	  }
 	| {
 			action: 'post' | 'post_redirect';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -34,7 +34,7 @@ export type OpenFrameButtonResult =
 			action: 'link' | 'mint';
 			target: string;
 			label: string;
-			postUrl?: never;
+			postUrl: never;
 	  }
 	| {
 			action: 'post' | 'post_redirect';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -34,7 +34,7 @@ export type OpenFrameButtonResult =
 			action: 'link' | 'mint';
 			target: string;
 			label: string;
-			postUrl?: string;
+			postUrl?: never;
 	  }
 	| {
 			action: 'post' | 'post_redirect';


### PR DESCRIPTION
`frameInfo` wasn't returning the button `post_url` on the client, which is needed if we want to pull from there instead of `extractedTags` in the metadata. Also updated an associated test for this.